### PR TITLE
Fix build workflow artifacts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,8 +38,8 @@ jobs:
       - name: Generate Version Logic
         id: selected-version
         run: |
-          VERSION="${GITHUB_REF_NAME}"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          VERSION=$(grep '^release-version=' build.properties | cut -d'=' -f2)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "BUILD_VERSION=$VERSION" > version.txt
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
@@ -61,6 +61,7 @@ jobs:
       COMPRESS_DIR: compress
       TEST_DIR: test
       COIN_NAME: bitoreum
+      RELEASE_DIR: bitoreum-v${{ needs.get-version.outputs.version }}
 
     steps:
       - name: Checkout
@@ -94,49 +95,30 @@ jobs:
           make -j$(nproc)
           mkdir -p ${BUILD_DIR}_debug
           cp src/{bitoreum-cli,bitoreumd,bitoreum-tx,qt/bitoreum-qt} ${BUILD_DIR}_debug/
-      - name: Generate Checksum and Compress
+      - name: Organize Artifacts
         run: |
-          mkdir -p ${COMPRESS_DIR}
+          mkdir -p ${RELEASE_DIR}
           for dir in "${BUILD_DIR}" "${BUILD_DIR}_debug" "${BUILD_DIR}_not_strip"; do
             case $dir in
               *debug) suffix="debug" ;;
               *_not_strip) suffix="notstrip" ;;
               *) suffix="release" ;;
             esac
-            rm -rf temp
-            mkdir -p temp/bitoreum-build
-            # Copy binaries into build folder
-            cp $dir/bitoreum-cli $dir/bitoreumd $dir/bitoreum-qt $dir/bitoreum-tx temp/bitoreum-build/
-            # Generate checksums inside the build folder
-            pushd temp/bitoreum-build
+            target="${RELEASE_DIR}/${suffix}"
+            mkdir -p "$target"
+            cp $dir/bitoreum-cli $dir/bitoreumd $dir/bitoreum-qt $dir/bitoreum-tx "$target/"
+            pushd "$target"
             echo "sha256:" > checksums.txt
-            echo "------------------------------------" >> checksums.txt
             shasum bitoreum-cli bitoreumd bitoreum-qt bitoreum-tx >> checksums.txt
-            echo "------------------------------------" >> checksums.txt
             echo "openssl-sha256:" >> checksums.txt
-            echo "------------------------------------" >> checksums.txt
             sha256sum bitoreum-cli bitoreumd bitoreum-qt bitoreum-tx >> checksums.txt
             popd
-            # Compress into tarball with structured name
-            tar -czf ${COIN_NAME}-${OS}-${ARCH_TYPE}-${suffix}-${{ needs.get-version.outputs.version }}.tar.gz -C temp bitoreum-build
           done
-          mv *.tar.gz ${COMPRESS_DIR}/
-          # Global checksums for tarballs
-          cd ${COMPRESS_DIR}
-          echo "Checksums for release archives:" > checksums.txt
-          echo "------------------------------------" >> checksums.txt
-          for f in *.tar.gz; do
-            echo "$f" >> checksums.txt
-            echo "sha256: $(shasum $f)" >> checksums.txt
-            echo "openssl-sha256: $(sha256sum $f)" >> checksums.txt
-            echo "------------------------------------" >> checksums.txt
-          done
-          cat checksums.txt
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.COIN_NAME }}-${{ env.OS }}-${{ env.ARCH_TYPE }}-${{ needs.get-version.outputs.version }}
-          path: ${{ env.COMPRESS_DIR }}
+          path: ${{ env.RELEASE_DIR }}
       - name: Upload Test Artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -155,6 +137,7 @@ jobs:
       COMPRESS_DIR: compress
       TEST_DIR: test
       COIN_NAME: bitoreum
+      RELEASE_DIR: bitoreum-v${{ needs.get-version.outputs.version }}
 
     steps:
       - name: Checkout
@@ -188,45 +171,30 @@ jobs:
           make -j$(nproc)
           mkdir -p ${BUILD_DIR}_debug
           cp src/{bitoreum-cli,bitoreumd,bitoreum-tx,qt/bitoreum-qt} ${BUILD_DIR}_debug/
-      - name: Generate Checksum and Compress
+      - name: Organize Artifacts
         run: |
-          mkdir -p ${COMPRESS_DIR}
+          mkdir -p ${RELEASE_DIR}
           for dir in "${BUILD_DIR}" "${BUILD_DIR}_debug" "${BUILD_DIR}_not_strip"; do
             case $dir in
               *debug) suffix="debug" ;;
               *_not_strip) suffix="notstrip" ;;
               *) suffix="release" ;;
             esac
-            rm -rf temp
-            mkdir -p temp/bitoreum-build
-            cp $dir/bitoreum-cli $dir/bitoreumd $dir/bitoreum-qt $dir/bitoreum-tx temp/bitoreum-build/
-            pushd temp/bitoreum-build
+            target="${RELEASE_DIR}/${suffix}"
+            mkdir -p "$target"
+            cp $dir/bitoreum-cli $dir/bitoreumd $dir/bitoreum-qt $dir/bitoreum-tx "$target/"
+            pushd "$target"
             echo "sha256:" > checksums.txt
-            echo "------------------------------------" >> checksums.txt
             shasum bitoreum-cli bitoreumd bitoreum-qt bitoreum-tx >> checksums.txt
-            echo "------------------------------------" >> checksums.txt
             echo "openssl-sha256:" >> checksums.txt
-            echo "------------------------------------" >> checksums.txt
             sha256sum bitoreum-cli bitoreumd bitoreum-qt bitoreum-tx >> checksums.txt
             popd
-            tar -czf ${COIN_NAME}-${OS}-${ARCH_TYPE}-${suffix}-${{ needs.get-version.outputs.version }}.tar.gz -C temp bitoreum-build
           done
-          mv *.tar.gz ${COMPRESS_DIR}/
-          cd ${COMPRESS_DIR}
-          echo "Checksums for release archives:" > checksums.txt
-          echo "------------------------------------" >> checksums.txt
-          for f in *.tar.gz; do
-            echo "$f" >> checksums.txt
-            echo "sha256: $(shasum $f)" >> checksums.txt
-            echo "openssl-sha256: $(sha256sum $f)" >> checksums.txt
-            echo "------------------------------------" >> checksums.txt
-          done
-          cat checksums.txt
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.COIN_NAME }}-${{ env.OS }}-${{ env.ARCH_TYPE }}-${{ needs.get-version.outputs.version }}
-          path: ${{ env.COMPRESS_DIR }}
+          path: ${{ env.RELEASE_DIR }}
       - name: Upload Test Artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -240,6 +208,7 @@ jobs:
     env:
       ARCH_TYPE: x86
       OS: win64
+      RELEASE_DIR: bitoreum-v${{ needs.get-version.outputs.version }}
 
     steps:
       - name: Checkout
@@ -277,34 +246,25 @@ jobs:
           make -j$(nproc)
           mkdir -p ${BUILD_DIR}_debug
           cp src/{bitoreum-cli.exe,bitoreumd.exe,bitoreum-tx.exe,qt/bitoreum-qt.exe} ${BUILD_DIR}_debug/
-      - name: Generate Checksum and Compress
+      - name: Organize Artifacts
         run: |
-          mkdir -p ${COMPRESS_DIR}
-          cd ${BUILD_DIR}
-          echo "sha256:" > checksums.txt
-          shasum * >> checksums.txt
-          echo "openssl-sha256:" >> checksums.txt
-          sha256sum * >> checksums.txt
-          zip -r ../${COIN_NAME}-${OS}-${ARCH_TYPE}-release-${{ needs.get-version.outputs.version }}.zip .
-          cd ../${BUILD_DIR}_not_strip
-          echo "sha256:" > checksums.txt
-          shasum * >> checksums.txt
-          echo "openssl-sha256:" >> checksums.txt
-          sha256sum * >> checksums.txt
-          zip -r ../${COIN_NAME}-${OS}-${ARCH_TYPE}-notstrip-${{ needs.get-version.outputs.version }}.zip .
-          cd ..
-          mv *.zip ${COMPRESS_DIR}/
-          cd ${COMPRESS_DIR}
-          for f in *.zip; do
-            echo "sha256: $(shasum $f)" >> checksums.txt
-            echo "openssl-sha256: $(sha256sum $f)" >> checksums.txt
+          mkdir -p ${RELEASE_DIR}/release ${RELEASE_DIR}/notstrip ${RELEASE_DIR}/debug
+          cp ${BUILD_DIR}/*.exe ${RELEASE_DIR}/release/
+          cp ${BUILD_DIR}_not_strip/*.exe ${RELEASE_DIR}/notstrip/
+          cp ${BUILD_DIR}_debug/*.exe ${RELEASE_DIR}/debug/
+          for d in release notstrip debug; do
+            pushd ${RELEASE_DIR}/$d
+            echo "sha256:" > checksums.txt
+            shasum *.exe >> checksums.txt
+            echo "openssl-sha256:" >> checksums.txt
+            sha256sum *.exe >> checksums.txt
+            popd
           done
-          cat checksums.txt
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.COIN_NAME }}-${{ env.OS }}-${{ env.ARCH_TYPE }}-${{ needs.get-version.outputs.version }}
-          path: ${{ env.COMPRESS_DIR }}
+          path: ${{ env.RELEASE_DIR }}
 
       - name: Upload Test Artifacts
         uses: actions/upload-artifact@v4
@@ -324,6 +284,9 @@ jobs:
           echo "sha256: $(shasum $final)" >> checksums.txt
           echo "openssl-sha256: $(sha256sum $final)" >> checksums.txt
           cat checksums.txt
+          mkdir -p ../${RELEASE_DIR}/installer
+          cp "$final" ../${RELEASE_DIR}/installer/
+          cp checksums.txt ../${RELEASE_DIR}/installer/
       - name: Upload Win64 Installation File
         uses: actions/upload-artifact@v4
         with:
@@ -341,6 +304,7 @@ jobs:
       COMPRESS_DIR: compress
       TEST_DIR: test
       COIN_NAME: bitoreum
+      RELEASE_DIR: bitoreum-v${{ needs.get-version.outputs.version }}
 
     steps:
       - name: Checkout
@@ -374,51 +338,30 @@ jobs:
           make -j$(nproc)
           mkdir -p ${BUILD_DIR}_debug
           cp src/{bitoreum-cli,bitoreumd,bitoreum-tx,qt/bitoreum-qt} ${BUILD_DIR}_debug/
-      - name: Generate Checksum and Compress
+      - name: Organize Artifacts
         run: |
-          mkdir -p ${COMPRESS_DIR}
+          mkdir -p ${RELEASE_DIR}
           for dir in "${BUILD_DIR}" "${BUILD_DIR}_debug" "${BUILD_DIR}_not_strip"; do
             case $dir in
               *debug) suffix="debug" ;;
               *_not_strip) suffix="notstrip" ;;
               *) suffix="release" ;;
             esac
-            # Set up a clean temp staging folder
-            rm -rf temp
-            mkdir -p temp/bitoreum-build
-            # Copy only the desired binaries into the build folder
-            cp $dir/bitoreum-cli $dir/bitoreumd $dir/bitoreum-qt $dir/bitoreum-tx temp/bitoreum-build/
-            # Create checksums for the binaries inside bitoreum-build
-            pushd temp/bitoreum-build
+            target="${RELEASE_DIR}/${suffix}"
+            mkdir -p "$target"
+            cp $dir/bitoreum-cli $dir/bitoreumd $dir/bitoreum-qt $dir/bitoreum-tx "$target/"
+            pushd "$target"
             echo "sha256:" > checksums.txt
-            echo "------------------------------------" >> checksums.txt
             shasum bitoreum-cli bitoreumd bitoreum-qt bitoreum-tx >> checksums.txt
-            echo "------------------------------------" >> checksums.txt
             echo "openssl-sha256:" >> checksums.txt
-            echo "------------------------------------" >> checksums.txt
             sha256sum bitoreum-cli bitoreumd bitoreum-qt bitoreum-tx >> checksums.txt
             popd
-            # Compress the bitoreum-build folder with contents
-            tar -czf ${COIN_NAME}-${OS}-${ARCH_TYPE}-${suffix}-${{ needs.get-version.outputs.version }}.tar.gz -C temp bitoreum-build
           done
-          # Move final .tar.gz files into compress dir
-          mv *.tar.gz ${COMPRESS_DIR}/
-          # Generate global checksum for all archives
-          cd ${COMPRESS_DIR}
-          echo "Checksums for release archives:" > checksums.txt
-          echo "------------------------------------" >> checksums.txt
-          for f in *.tar.gz; do
-            echo "$f" >> checksums.txt
-            echo "sha256: $(shasum $f)" >> checksums.txt
-            echo "openssl-sha256: $(sha256sum $f)" >> checksums.txt
-            echo "------------------------------------" >> checksums.txt
-          done
-          cat checksums.txt
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.COIN_NAME }}-${{ env.OS }}-${{ env.ARCH_TYPE }}-${{ needs.get-version.outputs.version }}
-          path: ${{ env.COMPRESS_DIR }}
+          path: ${{ env.RELEASE_DIR }}
       - name: Upload Test Artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -437,6 +380,7 @@ jobs:
       COMPRESS_DIR: compress
       TEST_DIR: test
       COIN_NAME: bitoreum
+      RELEASE_DIR: bitoreum-v${{ needs.get-version.outputs.version }}
 
     steps:
       - name: Checkout
@@ -470,49 +414,30 @@ jobs:
           make -j$(nproc)
           mkdir -p ${BUILD_DIR}_debug
           cp src/{bitoreum-cli,bitoreumd,bitoreum-tx,qt/bitoreum-qt} ${BUILD_DIR}_debug/
-      - name: Generate Checksum and Compress
+      - name: Organize Artifacts
         run: |
-          mkdir -p ${COMPRESS_DIR}
+          mkdir -p ${RELEASE_DIR}
           for dir in "${BUILD_DIR}" "${BUILD_DIR}_debug" "${BUILD_DIR}_not_strip"; do
             case $dir in
               *debug) suffix="debug" ;;
               *_not_strip) suffix="notstrip" ;;
               *) suffix="release" ;;
             esac
-            rm -rf temp
-            mkdir -p temp/bitoreum-build
-            # Copy target binaries
-            cp $dir/bitoreum-cli $dir/bitoreumd $dir/bitoreum-qt $dir/bitoreum-tx temp/bitoreum-build/
-            # Generate checksums inside the folder
-            pushd temp/bitoreum-build
+            target="${RELEASE_DIR}/${suffix}"
+            mkdir -p "$target"
+            cp $dir/bitoreum-cli $dir/bitoreumd $dir/bitoreum-qt $dir/bitoreum-tx "$target/"
+            pushd "$target"
             echo "sha256:" > checksums.txt
-            echo "------------------------------------" >> checksums.txt
             shasum bitoreum-cli bitoreumd bitoreum-qt bitoreum-tx >> checksums.txt
-            echo "------------------------------------" >> checksums.txt
             echo "openssl-sha256:" >> checksums.txt
-            echo "------------------------------------" >> checksums.txt
             sha256sum bitoreum-cli bitoreumd bitoreum-qt bitoreum-tx >> checksums.txt
             popd
-            # Compress it
-            tar -czf ${COIN_NAME}-${OS}-${ARCH_TYPE}-${suffix}-${{ needs.get-version.outputs.version }}.tar.gz -C temp bitoreum-build
           done
-          mv *.tar.gz ${COMPRESS_DIR}/
-          # Generate global checksums for release artifacts
-          cd ${COMPRESS_DIR}
-          echo "Checksums for release archives:" > checksums.txt
-          echo "------------------------------------" >> checksums.txt
-          for f in *.tar.gz; do
-            echo "$f" >> checksums.txt
-            echo "sha256: $(shasum $f)" >> checksums.txt
-            echo "openssl-sha256: $(sha256sum $f)" >> checksums.txt
-            echo "------------------------------------" >> checksums.txt
-          done
-          cat checksums.txt
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.COIN_NAME }}-${{ env.OS }}-${{ env.ARCH_TYPE }}-${{ needs.get-version.outputs.version }}
-          path: ${{ env.COMPRESS_DIR }}
+          path: ${{ env.RELEASE_DIR }}
 
       - name: Upload Test Artifacts
         uses: actions/upload-artifact@v4
@@ -524,6 +449,9 @@ jobs:
     name: macOS 13 x86 Build
     needs: get-version
     runs-on: macos-13
+
+    env:
+      RELEASE_DIR: bitoreum-v${{ needs.get-version.outputs.version }}
 
     steps:
       - name: Checkout
@@ -554,44 +482,25 @@ jobs:
           mv src/test/test_bitoreum ${TEST_DIR}
           strip ${BUILD_DIR}/*
 
-      - name: Generate Checksum and Compress
+      - name: Organize Artifacts
         run: |
-          cd ${BUILD_DIR}
-          echo "sha256:" >> checksums.txt
-          echo "------------------------------------" >> checksums.txt
-          shasum * >> checksums.txt
-          echo "------------------------------------" >> checksums.txt
-          echo "openssl-sha256:" >> checksums.txt
-          echo "------------------------------------" >> checksums.txt
-          openssl sha256 * >> checksums.txt
-          cat checksums.txt
-          tar -cvzf ../${COIN_NAME}-macOS13-x86-${{ needs.get-version.outputs.version }}.tar.gz ../${BUILD_DIR}/*
-          cd ../${BUILD_DIR}_not_strip
-          echo "sha256:" >> checksums.txt
-          echo "------------------------------------" >> checksums.txt
-          shasum * >> checksums.txt
-          echo "------------------------------------" >> checksums.txt
-          echo "openssl-sha256:" >> checksums.txt
-          echo "------------------------------------" >> checksums.txt
-          openssl sha256 * >> checksums.txt
-          cat checksums.txt
-          tar -cvzf ../${COIN_NAME}-macOS13-x86-not_strip-${{ needs.get-version.outputs.version }}.tar.gz *
-          cd ..
-          mkdir -p ${COMPRESS_DIR}
-          mv *.tar.gz ${COMPRESS_DIR}/
-          cd ${COMPRESS_DIR}
-          echo "sha256: $(shasum ${COIN_NAME}-macOS13-x86-${{ needs.get-version.outputs.version }}.tar.gz)" >> checksums.txt
-          echo "openssl-sha256: $(openssl sha256 ${COIN_NAME}-macOS13-x86-${{ needs.get-version.outputs.version }}.tar.gz)" >> checksums.txt
-          echo "sha256: $(shasum ${COIN_NAME}-macOS13-x86-not_strip-${{ needs.get-version.outputs.version }}.tar.gz)" >> checksums.txt
-          echo "openssl-sha256: $(openssl sha256 ${COIN_NAME}-macOS13-x86-not_strip-${{ needs.get-version.outputs.version }}.tar.gz)" >> checksums.txt
-          cat checksums.txt
-          cd ..
+          mkdir -p ${RELEASE_DIR}/release ${RELEASE_DIR}/notstrip
+          cp ${BUILD_DIR}/* ${RELEASE_DIR}/release/
+          cp ${BUILD_DIR}_not_strip/* ${RELEASE_DIR}/notstrip/
+          for d in release notstrip; do
+            pushd ${RELEASE_DIR}/$d
+            echo "sha256:" > checksums.txt
+            shasum * >> checksums.txt
+            echo "openssl-sha256:" >> checksums.txt
+            openssl sha256 * >> checksums.txt
+            popd
+          done
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.COIN_NAME }}-macOS13-x86-${{ needs.get-version.outputs.version }}
-          path: ${{ env.COMPRESS_DIR }}
+          path: ${{ env.RELEASE_DIR }}
 
       - name: Upload Test Artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- read release version from `build.properties`
- simplify artifact creation so builds are placed into `bitoreum-v<version>`
- remove tar/zip compression steps
- preserve installer/dmg artifacts but copy them into release directory

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869989fc4a48326bee246bb7c88a056